### PR TITLE
Do not delete anything

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,4 @@ android.bundle.language.enableSplit=false
 org.gradle.jvmargs=-Xmx4096M
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+org.gradle.java.installations.auto-download=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
Enable Gradle toolchain auto-download and add Foojay resolver to allow automatic fetching of required JDKs.

This change allows Gradle to automatically download JDK 8, which is necessary for building the `jre_lwjgl3glfw` module, ensuring all pure-Java modules can be built successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4890af8-a189-436f-a6dd-843db7c8c547">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4890af8-a189-436f-a6dd-843db7c8c547">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

